### PR TITLE
Rewrite SOLIDWORKS PDM upgrade and design reuse articles

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,7 +6,13 @@
 - Images referenced from <code>/assets/images</code> remain unchanged; alt text added or confirmed where missing.
 - Front matter dates use 2025-09-16 (current working date) until original publication dates are identified.
 
+## 2025-09-16 (cont.)
+- [x] Rewrote "5 Reasons Why You Should Upgrade SOLIDWORKS Workgroup PDM" as <code>articles_rewrite/upgrade-workgroup-pdm-to-pdm-professional.md</code>, restructuring the five business drivers and modernizing captions while keeping legacy imagery in place.
+- [x] Rewrote "5 Ways PDM Can Help You Succeed Through Design Reuse" as <code>articles_rewrite/solidworks-pdm-design-reuse-benefits.md</code> with new headings, keyword-rich narrative, and a refined call to action.
+- [x] Verified image order via matching files in <code>articles_local/</code> and replaced each with simplified <code>&lt;figure&gt;</code> blocks and updated alt text.
+- Documented SOLIDWORKS PDM data management advantages, including references to custom columns and workflow automation where applicable.
+
 ### Next Steps for Future Agents
-- Continue processing remaining articles in <code>articles_raw/</code>; match each to the corresponding HTML in <code>articles_local/</code> to confirm image placement.
-- Maintain the established Markdown structure with front matter, HTML headings, and <code>&lt;figure&gt;</code> blocks for images.
-- Update this log with newly completed articles and any deviations or discoveries (e.g., missing images or metadata).
+- Continue processing remaining articles in <code>articles_raw/</code>; consult <code>articles_local/</code> before rewriting to confirm image placement and any embedded assets.
+- Maintain the established Markdown structure with YAML front matter, HTML headings, and <code>&lt;figure&gt;</code> blocks for images and captions.
+- Prioritize nearby topics such as <code>articles_raw/5-ways-project-management-just-got-easier.txt</code> or subsequent workflow-related pieces, and note any missing imagery or metadata encountered.

--- a/articles_rewrite/solidworks-pdm-design-reuse-benefits.md
+++ b/articles_rewrite/solidworks-pdm-design-reuse-benefits.md
@@ -1,0 +1,41 @@
+---
+title: "5 Ways SOLIDWORKS PDM Drives Successful Design Reuse"
+date: 2025-09-16
+categories: [solidworks-pdm]
+tags: [SOLIDWORKS PDM, data management, design reuse, engineering efficiency]
+description: "Discover how SOLIDWORKS PDM streamlines design reuse with faster searches, accurate quotes, and enterprise-wide collaboration."
+slug: "solidworks-pdm-design-reuse-benefits"
+---
+
+<p>Spending hours searching network drives for the right revision—or worse, recreating a part you know already exists—erodes engineering efficiency. Without integrated data management, even well-organized teams can lose track of proven concepts that would accelerate the next project.</p>
+
+<figure>
+  <img src="/assets/images/epdm-in-use.jpg" alt="Engineer managing design data inside SOLIDWORKS PDM" width="1000" height="667" />
+  <figcaption>SOLIDWORKS PDM keeps design intelligence close at hand for every project.</figcaption>
+</figure>
+
+<p>An integrated SOLIDWORKS PDM environment gives you immediate visibility into prior work, reducing duplicate effort and revealing reusable assets created by colleagues. Instead of starting from scratch, you can build on trusted data, respond to customer requests faster, and keep projects on schedule.</p>
+
+<h2>Leverage proven designs to stay competitive</h2>
+
+<p>Design reuse is a strategic advantage in global markets where speed and accuracy determine who wins the bid. Reapplying validated models shrinks time-to-market, minimizes rework, and protects margins. SOLIDWORKS PDM consolidates design artifacts, quotes, drawings, and BOMs in a single source of truth so cross-functional teams always know which configuration is current.</p>
+
+<p>When marketing, sales, and manufacturing rely on the same vault, everyone can operate in parallel instead of waiting for handoffs. That collaboration helps you capture more business and deliver consistent customer experiences.</p>
+
+<h2>Turn reuse into a managed, repeatable process</h2>
+
+<p>Successful design reuse hinges on structured workflows. SOLIDWORKS PDM combines lifecycle states, automated notifications, and configurable data cards to organize intellectual property for rapid retrieval. Administrators can expose saved searches, custom columns, and dashboards that highlight preferred components, allowing engineers to locate qualified parts in seconds.</p>
+
+<p>The same platform records who created, approved, and released each item—maintaining the traceability you need for audits while keeping teams aligned on which version to trust.</p>
+
+<h3>Download the white paper to learn how SOLIDWORKS PDM will:</h3>
+
+<ol>
+  <li>Slash design time by eliminating redundant modeling.</li>
+  <li>Leverage proven concepts to accelerate development cycles.</li>
+  <li>Increase quoting speed and accuracy with reliable reference data.</li>
+  <li>Reduce data duplication and prevent unnecessary part numbers.</li>
+  <li>Integrate resources from all departments through shared workflows.</li>
+</ol>
+
+<p>Equip your organization with the processes and technology to capitalize on every design you create. <strong><a href="https://www.javelin-tech.com/blog/about-javelin-technologies/">Contact the TriMech Group</a></strong> to request the full design reuse white paper and explore how SOLIDWORKS PDM can elevate your product development strategy.</p>

--- a/articles_rewrite/upgrade-workgroup-pdm-to-pdm-professional.md
+++ b/articles_rewrite/upgrade-workgroup-pdm-to-pdm-professional.md
@@ -1,0 +1,124 @@
+---
+title: "Upgrade from SOLIDWORKS Workgroup PDM: 5 Reasons to Move to PDM Professional"
+date: 2025-09-16
+categories: [solidworks-pdm]
+tags: [SOLIDWORKS PDM, data management, workflow automation, design reuse]
+description: "Learn why teams outgrow SOLIDWORKS Workgroup PDM and how SOLIDWORKS PDM Professional supports secure, scalable data management."
+slug: "upgrade-workgroup-pdm-to-pdm-professional"
+---
+
+<p>Growing design teams quickly run into the limits of SOLIDWORKS Workgroup PDM. When you need secure collaboration outside engineering, tighter integrations with enterprise systems, or controlled automation, SOLIDWORKS PDM Professional delivers the enterprise-grade data management platform to keep product development moving.</p>
+
+<figure>
+  <img src="/assets/images/design-team.jpg" alt="Product development team collaborating on CAD data" width="1000" height="500" />
+  <figcaption>Scaling collaboration means extending data access beyond the core design group.</figcaption>
+</figure>
+
+<p>The five considerations below outline why organizations upgrade to SOLIDWORKS PDM Professional and how the platform elevates governance, visibility, and reuse.</p>
+
+<h2>1. Extend secure access across every department</h2>
+
+<p>SOLIDWORKS PDM Professional retains the familiar Windows Explorer interface while expanding control to any department that needs product data. Marketing can pull approved renderings earlier for campaigns, purchasing can quote against released drawings, and manufacturing can plan production from accurate BOMs without waiting for email handoffs.</p>
+
+<p>Administrators can replicate vaults to regional servers or expose SOLIDWORKS PDM Web2 for browser-based access, ensuring remote stakeholders stay synchronized through the same controlled vault.</p>
+
+<figure>
+  <img src="/assets/images/epdm-windows-explorer.jpg" alt="SOLIDWORKS PDM Professional interface in Windows Explorer" width="1000" height="666" />
+  <figcaption>Windows Explorer integration keeps SOLIDWORKS PDM Professional intuitive for cross-functional teams.</figcaption>
+</figure>
+
+<h2>2. Connect SOLIDWORKS PDM with enterprise business systems</h2>
+
+<p>As operations scale, your PDM environment must interact with ERP, MRP, CRM, and PLM solutions. SOLIDWORKS PDM Professional uses Microsoft SQL Server and an open API (COM, VB, C#) so you can automate data exchanges with platforms such as SAP or Microsoft Dynamics. Linking vault metadata to downstream systems eliminates duplicate entry, drives consistency, and keeps procurement, finance, and service teams aligned.</p>
+
+<figure>
+  <img src="/assets/images/erp-system.jpg" alt="ERP dashboard connected to SOLIDWORKS PDM data" width="1000" height="666" />
+  <figcaption>Integrations between SOLIDWORKS PDM and ERP systems reduce manual data entry.</figcaption>
+</figure>
+
+<h2>3. Standardize and automate engineering workflows</h2>
+
+<p>SOLIDWORKS PDM Professional lets you build workflows that mirror your release process, ensuring every change follows consistent review gates. Automated notifications, state-based permissions, and background tasks—like generating PDFs or neutral CAD files—keep teams accountable while accelerating deliverables.</p>
+
+<p>Whether your contributors are on-site or remote, the workflow engine encourages collaboration on engineering change orders, design reviews, and approval cycles without bypassing required checks.</p>
+
+<figure>
+  <img src="/assets/images/epdm-workflow.jpg" alt="SOLIDWORKS PDM Professional workflow diagram" width="1000" height="500" />
+  <figcaption>Workflow automation enforces repeatable approvals and traceable change history.</figcaption>
+</figure>
+
+<h2>4. Accelerate search, reuse, and scalability</h2>
+
+<p>SOLIDWORKS PDM Professional’s indexed search spans filenames, metadata, workflow state, and custom columns so teams can retrieve the exact revision they need in seconds. Classifying data on file cards and sharing saved searches promotes design reuse, cutting redundant modeling work and improving quoting accuracy.</p>
+
+<p>Distributed teams benefit from dedicated archive and database servers that handle replication and remote caching. Engineers get fast file transfers across the WAN, while IT maintains centralized control over revisions and permissions.</p>
+
+<figure>
+  <img src="/assets/images/3DVIA-in-EPDM.gif" alt="SOLIDWORKS PDM search results featuring composer content" width="1596" height="844" />
+  <figcaption>Advanced search and custom columns surface reusable content for every department.</figcaption>
+</figure>
+
+<h2>5. Strengthen ISO-compliant traceability</h2>
+
+<p>PDM Professional automatically records a complete audit trail for every file, assembly, and project. Version history, approvals, and state changes are documented without manual effort, helping you satisfy ISO requirements and internal quality metrics. Auditors gain instant visibility into who approved what, when, and why—protecting your organization during compliance reviews.</p>
+
+<h3>Key SOLIDWORKS PDM Professional capabilities</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Capability</th>
+      <th scope="col">What it delivers</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Secure access</strong></td>
+      <td>Role-based permissions protect IP while enabling partners, customers, and suppliers to collaborate through controlled portals.</td>
+    </tr>
+    <tr>
+      <td><strong>Revision control</strong></td>
+      <td>Automated versioning prevents overwrites and keeps purchasing and production aligned with the latest approved data.</td>
+    </tr>
+    <tr>
+      <td><strong>Powerful search</strong></td>
+      <td>Metadata-driven queries find files instantly, boosting engineering throughput and accuracy.</td>
+    </tr>
+    <tr>
+      <td><strong>Scalability</strong></td>
+      <td>Dedicated archive and database services maintain performance as your data set grows across sites.</td>
+    </tr>
+    <tr>
+      <td><strong>Configurable experience</strong></td>
+      <td>Administrators tailor workflows, custom columns, and vault views to match departmental processes.</td>
+    </tr>
+    <tr>
+      <td><strong>Design reuse</strong></td>
+      <td>Structured classifications and saved searches let teams quickly repurpose proven components.</td>
+    </tr>
+    <tr>
+      <td><strong>Rich previews</strong></td>
+      <td>View and print more than 250 file formats—including CAD, office documents, and media—without launching desktop applications.</td>
+    </tr>
+    <tr>
+      <td><strong>Distributed collaboration</strong></td>
+      <td>Vault replication keeps multisite teams synchronized with up-to-date models and drawings.</td>
+    </tr>
+    <tr>
+      <td><strong>Remote productivity</strong></td>
+      <td>Web and mobile access give managers, sales, and field personnel the insight they need wherever they work.</td>
+    </tr>
+    <tr>
+      <td><strong>Automated approvals</strong></td>
+      <td>State transitions trigger required reviewers and background tasks to maintain compliance.</td>
+    </tr>
+    <tr>
+      <td><strong>Audit trail</strong></td>
+      <td>Complete history of decisions and changes simplifies regulatory reporting and continuous improvement.</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Upgrading to SOLIDWORKS PDM Professional gives growing organizations a secure, integrated foundation for data management, from initial concept to released product. The result is a connected enterprise that reuses knowledge, speeds delivery, and meets quality benchmarks with confidence.</p>
+
+<p><strong><a href="https://www.javelin-tech.com/blog/about-javelin-technologies/">Connect with the TriMech Group</a></strong> to plan your SOLIDWORKS PDM Professional deployment and unlock these benefits.</p>


### PR DESCRIPTION
## Summary
- rewrite the Workgroup-to-Professional upgrade article with refreshed structure, updated figures, and keyword-rich explanations of the five migration drivers
- rewrite the design reuse article to emphasize SOLIDWORKS PDM workflows, list the five business outcomes, and maintain the localized image
- extend PROGRESS.md with the latest completions, verification notes, and guidance for the next articles to tackle

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c9501a45dc832fbae08922a03d3277