### PR TITLE
Use local parentcode script for assistant and theme toggles

### DIFF
--- a/articles_html/5 Ways PDM can help you succeed through Design Reu.html
+++ b/articles_html/5 Ways PDM can help you succeed through Design Reu.html
@@ -16,7 +16,7 @@
 	<div class="fl-module-content fl-node-content">
 		<div class="fl-html">
 	<!-- Pardot Form Start -->
-<script type="text/javascript" src="https://www.javelin-tech.com/3d/wp-content/themes/bb-theme-child/scripts/parentcode.js"></script>
+<script type="text/javascript" src="../assets/js/parentcode.js"></script>
 <script type="text/javascript">
 // Pass URL parameters to form fields.
     var iframe = document.getElementById('pardotform');

--- a/articles_html/PLM – It’s All About the Product!.html
+++ b/articles_html/PLM – It’s All About the Product!.html
@@ -17,7 +17,7 @@
 	<div class="fl-module-content fl-node-content">
 		<div class="fl-html">
 	<!-- Pardot Form Start -->
-<script type="text/javascript" src="https://www.javelin-tech.com/3d/wp-content/themes/bb-theme-child/scripts/parentcode.js"></script>
+<script type="text/javascript" src="../assets/js/parentcode.js"></script>
 <script type="text/javascript">
 // Pass URL parameters to form fields.
     var iframe = document.getElementById('pardotform');

--- a/articles_html/Product Lifecycle Management Made Easy.html
+++ b/articles_html/Product Lifecycle Management Made Easy.html
@@ -15,7 +15,7 @@
 	<div class="fl-module-content fl-node-content">
 		<div class="fl-html">
 	<!-- Pardot Form Start -->
-<script type="text/javascript" src="https://www.javelin-tech.com/3d/wp-content/themes/bb-theme-child/scripts/parentcode.js"></script>
+<script type="text/javascript" src="../assets/js/parentcode.js"></script>
 <script type="text/javascript">
 // Pass URL parameters to form fields.
     var iframe = document.getElementById('pardotform');

--- a/articles_html/Realize the benefits of improved Data Management w.html
+++ b/articles_html/Realize the benefits of improved Data Management w.html
@@ -69,7 +69,7 @@
 	<div class="fl-module-content fl-node-content">
 		<div class="fl-html">
 	<!-- Pardot Form Start -->
-<script type="text/javascript" src="https://www.javelin-tech.com/3d/wp-content/themes/bb-theme-child/scripts/parentcode.js"></script>
+<script type="text/javascript" src="../assets/js/parentcode.js"></script>
 <script type="text/javascript">
 // Pass URL parameters to form fields.
     var iframe = document.getElementById('pardotform');

--- a/articles_html/SOLIDWORKS PDM Professional 2022 System Recommenda.html
+++ b/articles_html/SOLIDWORKS PDM Professional 2022 System Recommenda.html
@@ -101,7 +101,7 @@
 	<div class="fl-module-content fl-node-content">
 		<div class="fl-html">
 	<!-- Pardot Form Start -->
-<script type="text/javascript" src="https://www.javelin-tech.com/3d/wp-content/themes/bb-theme-child/scripts/parentcode.js"></script>
+<script type="text/javascript" src="../assets/js/parentcode.js"></script>
 <script type="text/javascript">
 // Pass URL parameters to form fields.
     var iframe = document.getElementById('pardotform');

--- a/articles_html/The Top Five Reasons for Manufacturers to Improve.html
+++ b/articles_html/The Top Five Reasons for Manufacturers to Improve.html
@@ -15,7 +15,7 @@
 	<div class="fl-module-content fl-node-content">
 		<div class="fl-html">
 	<!-- Pardot Form Start -->
-<script type="text/javascript" src="https://www.javelin-tech.com/3d/wp-content/themes/bb-theme-child/scripts/parentcode.js"></script>
+<script type="text/javascript" src="../assets/js/parentcode.js"></script>
 <script type="text/javascript">
 // Pass URL parameters to form fields.
     var iframe = document.getElementById('pardotform');

--- a/articles_local/5-ways-pdm-can-help-you-succeed-through-design-reu.html
+++ b/articles_local/5-ways-pdm-can-help-you-succeed-through-design-reu.html
@@ -16,7 +16,7 @@
 <div class="fl-module-content fl-node-content">
 <div class="fl-html">
 <!-- Pardot Form Start -->
-<script src="https://www.javelin-tech.com/3d/wp-content/themes/bb-theme-child/scripts/parentcode.js" type="text/javascript"></script>
+<script src="../assets/js/parentcode.js" type="text/javascript"></script>
 <script type="text/javascript">
 // Pass URL parameters to form fields.
     var iframe = document.getElementById('pardotform');

--- a/articles_local/plm-–-it’s-all-about-the-product!.html
+++ b/articles_local/plm-–-it’s-all-about-the-product!.html
@@ -17,7 +17,7 @@
 <div class="fl-module-content fl-node-content">
 <div class="fl-html">
 <!-- Pardot Form Start -->
-<script src="https://www.javelin-tech.com/3d/wp-content/themes/bb-theme-child/scripts/parentcode.js" type="text/javascript"></script>
+<script src="../assets/js/parentcode.js" type="text/javascript"></script>
 <script type="text/javascript">
 // Pass URL parameters to form fields.
     var iframe = document.getElementById('pardotform');

--- a/articles_local/product-lifecycle-management-made-easy.html
+++ b/articles_local/product-lifecycle-management-made-easy.html
@@ -15,7 +15,7 @@
 <div class="fl-module-content fl-node-content">
 <div class="fl-html">
 <!-- Pardot Form Start -->
-<script src="https://www.javelin-tech.com/3d/wp-content/themes/bb-theme-child/scripts/parentcode.js" type="text/javascript"></script>
+<script src="../assets/js/parentcode.js" type="text/javascript"></script>
 <script type="text/javascript">
 // Pass URL parameters to form fields.
     var iframe = document.getElementById('pardotform');

--- a/articles_local/realize-the-benefits-of-improved-data-management-w.html
+++ b/articles_local/realize-the-benefits-of-improved-data-management-w.html
@@ -69,7 +69,7 @@
 <div class="fl-module-content fl-node-content">
 <div class="fl-html">
 <!-- Pardot Form Start -->
-<script src="https://www.javelin-tech.com/3d/wp-content/themes/bb-theme-child/scripts/parentcode.js" type="text/javascript"></script>
+<script src="../assets/js/parentcode.js" type="text/javascript"></script>
 <script type="text/javascript">
 // Pass URL parameters to form fields.
     var iframe = document.getElementById('pardotform');

--- a/articles_local/solidworks-pdm-professional-2022-system-recommenda.html
+++ b/articles_local/solidworks-pdm-professional-2022-system-recommenda.html
@@ -101,7 +101,7 @@
 <div class="fl-module-content fl-node-content">
 <div class="fl-html">
 <!-- Pardot Form Start -->
-<script src="https://www.javelin-tech.com/3d/wp-content/themes/bb-theme-child/scripts/parentcode.js" type="text/javascript"></script>
+<script src="../assets/js/parentcode.js" type="text/javascript"></script>
 <script type="text/javascript">
 // Pass URL parameters to form fields.
     var iframe = document.getElementById('pardotform');

--- a/articles_local/the-top-five-reasons-for-manufacturers-to-improve.html
+++ b/articles_local/the-top-five-reasons-for-manufacturers-to-improve.html
@@ -15,7 +15,7 @@
 <div class="fl-module-content fl-node-content">
 <div class="fl-html">
 <!-- Pardot Form Start -->
-<script src="https://www.javelin-tech.com/3d/wp-content/themes/bb-theme-child/scripts/parentcode.js" type="text/javascript"></script>
+<script src="../assets/js/parentcode.js" type="text/javascript"></script>
 <script type="text/javascript">
 // Pass URL parameters to form fields.
     var iframe = document.getElementById('pardotform');

--- a/assets/js/parentcode.js
+++ b/assets/js/parentcode.js
@@ -1,0 +1,119 @@
+(function () {
+  "use strict";
+
+  function ready(callback) {
+    if (document.readyState !== "loading") {
+      callback();
+    } else {
+      document.addEventListener("DOMContentLoaded", callback, { once: true });
+    }
+  }
+
+  function applyTheme(theme) {
+    var root = document.documentElement;
+    var normalized = theme === "dark" ? "dark" : "light";
+    root.setAttribute("data-theme", normalized);
+    root.classList.remove("theme-light", "theme-dark");
+    root.classList.add("theme-" + normalized);
+
+    try {
+      window.localStorage.setItem("preferred-theme", normalized);
+    } catch (error) {
+      // Ignore storage errors (private mode, etc.)
+    }
+
+    return normalized;
+  }
+
+  function readStoredTheme() {
+    try {
+      return window.localStorage.getItem("preferred-theme");
+    } catch (error) {
+      return null;
+    }
+  }
+
+  ready(function () {
+    var assistantButton =
+      document.querySelector("[data-assistant-button]") ||
+      document.querySelector("#assistant-button");
+
+    var assistantPanel =
+      document.querySelector("[data-assistant-panel]") ||
+      document.querySelector("#assistant-panel");
+
+    var assistantCloseButtons = Array.prototype.slice.call(
+      document.querySelectorAll("[data-assistant-dismiss], [data-assistant-close], #assistant-close")
+    );
+
+    function openAssistant(event) {
+      if (event) {
+        event.preventDefault();
+      }
+
+      if (assistantPanel) {
+        assistantPanel.classList.add("is-visible");
+        assistantPanel.removeAttribute("aria-hidden");
+        document.body.classList.add("assistant-open");
+        if (assistantButton) {
+          assistantButton.setAttribute("aria-expanded", "true");
+        }
+      } else if (assistantButton && assistantButton.dataset.assistantUrl) {
+        var target = assistantButton.getAttribute("target") || "_blank";
+        window.open(assistantButton.dataset.assistantUrl, target, "noopener");
+      }
+    }
+
+    function closeAssistant(event) {
+      if (event) {
+        event.preventDefault();
+      }
+
+      if (assistantPanel) {
+        assistantPanel.classList.remove("is-visible");
+        assistantPanel.setAttribute("aria-hidden", "true");
+        document.body.classList.remove("assistant-open");
+      }
+
+      if (assistantButton) {
+        assistantButton.setAttribute("aria-expanded", "false");
+      }
+    }
+
+    if (assistantButton) {
+      assistantButton.addEventListener("click", openAssistant);
+    }
+
+    if (assistantPanel) {
+      assistantPanel.addEventListener("click", function (event) {
+        if (event.target === assistantPanel) {
+          closeAssistant(event);
+        }
+      });
+    }
+
+    assistantCloseButtons.forEach(function (button) {
+      button.addEventListener("click", closeAssistant);
+    });
+
+    var storedTheme = readStoredTheme();
+    var prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+    var initialTheme = storedTheme || (prefersDark ? "dark" : "light");
+    var currentTheme = applyTheme(initialTheme);
+
+    var themeToggle =
+      document.querySelector("[data-theme-toggle]") ||
+      document.querySelector("#theme-toggle");
+
+    if (themeToggle) {
+      themeToggle.setAttribute("aria-pressed", currentTheme === "dark" ? "true" : "false");
+
+      themeToggle.addEventListener("click", function (event) {
+        event.preventDefault();
+        var newTheme = document.documentElement.getAttribute("data-theme") === "dark" ? "light" : "dark";
+        applyTheme(newTheme);
+        themeToggle.setAttribute("aria-pressed", newTheme === "dark" ? "true" : "false");
+      });
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add a local `parentcode.js` that wires assistant launch and theme toggle handlers while persisting the preferred theme
- switch article templates to load the new local script instead of the remote WordPress asset

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1c2408f3c832fbaaf69d4f8aef01e